### PR TITLE
feat: add support for SOA records in private DNS zone configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -290,6 +290,7 @@ resource "azurerm_private_dns_zone" "zone" {
       zone_key => {
         name           = zone.name
         resource_group = try(zone.resource_group, var.resource_group)
+        soa_record     = try(zone.soa_record, null)
         tags           = try(zone.tags, var.tags, null)
       }
       if try(zone.use_existing_zone, false) == false && !tobool(try(var.zones.private.use_predefined_zones, false))
@@ -300,6 +301,7 @@ resource "azurerm_private_dns_zone" "zone" {
       name => {
         name           = zone.name
         resource_group = var.resource_group
+        soa_record     = try(zone.soa_record, null)
         tags           = var.tags
       }
       if try(lookup(var.zones.private, "use_predefined_zones", false), false)
@@ -310,6 +312,19 @@ resource "azurerm_private_dns_zone" "zone" {
   resource_group_name = each.value.resource_group
   tags                = each.value.tags
 
+  dynamic "soa_record" {
+    for_each = each.value.soa_record != null ? [each.value.soa_record] : []
+
+    content {
+      email        = soa_record.value.email
+      expire_time  = try(soa_record.value.expire_time, 2419200)
+      minimum_ttl  = try(soa_record.value.minimum_ttl, 10)
+      refresh_time = try(soa_record.value.refresh_time, 3600)
+      retry_time   = try(soa_record.value.retry_time, 300)
+      ttl          = try(soa_record.value.ttl, 3600)
+      tags         = soa_record.value.tags
+    }
+  }
 }
 
 # private dns a records


### PR DESCRIPTION
## Description

azurerm_private_dns_zone: Missing optional block soa_record in root


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

azurerm_private_dns_zone: Added optional block soa_record in root

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes [#49](https://github.com/CloudNationHQ/terraform-azure-pdns/issues/49)
